### PR TITLE
fix: missed currency code

### DIFF
--- a/epc/epc.go
+++ b/epc/epc.go
@@ -50,6 +50,9 @@ func (p *EpcPayment) GenerateString() (string, error) {
 	res.WriteString(base.TrimToLength(p.IBAN, 34) + "\n")
 
 	if p.Amount != "" {
+		if p.Currency != "" {
+			res.WriteString(base.TrimToLength(p.Currency, 3))
+		}
 		res.WriteString(base.TrimToLength(p.Amount, 12))
 	}
 	res.WriteString("\n")

--- a/epc/epc_test.go
+++ b/epc/epc_test.go
@@ -37,7 +37,7 @@ func TestDEPayment(t *testing.T) {
 	p.SetAmount("10.8")
 
 	s, _ := p.GenerateString()
-	assert.Equal(t, "BCD\n002\n1\nSCT\nBHBLDEHHXXX\nFranz Mustermänn\nDE71110220330123456789\n10.8", s)
+	assert.Equal(t, "BCD\n002\n1\nSCT\nBHBLDEHHXXX\nFranz Mustermänn\nDE71110220330123456789\nEUR10.8", s)
 }
 
 func TestOtherParams(t *testing.T) {


### PR DESCRIPTION
Reference - https://de.wikipedia.org/wiki/EPC-QR-Code

```
Payment amount
optional but recommended
Value = Format “EUR#.##”, between 0.01 and 999999999.99
```